### PR TITLE
feat: Add benchmark configuration to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,7 @@ bincode = "1.3"
 [dev-dependencies]
 criterion = "0.5"
 
+[[bench]]
+name = "tpch_benchmark"
+harness = false
+


### PR DESCRIPTION
- Add [[bench]] section for tpch_benchmark
- Set harness = false for custom benchmark harness

This enables running TPCH benchmark tests using criterion.